### PR TITLE
Add missing `published` field to Announce

### DIFF
--- a/src/relay.rs
+++ b/src/relay.rs
@@ -174,6 +174,7 @@ pub fn spawn(
             };
             let mut seen_actors = HashSet::new();
             let mut seen_inboxes = HashSet::new();
+            let published = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
             for actor in post.relay_targets(hostname.clone()) {
                 if seen_actors.contains(&actor) {
                     continue;
@@ -185,6 +186,7 @@ pub fn spawn(
                     "@context": "https://www.w3.org/ns/activitystreams",
                     "type": "Announce",
                     "actor": *actor_id,
+                    "published": &published,
                     "to": ["https://www.w3.org/ns/activitystreams#Public"],
                     "object": &post.uri,
                     "id": announce_id,


### PR DESCRIPTION
Usually, `Announce` activities have the `published` field. This is breaking integration with GoToSocial, I had to [modify my GoToSocial code](https://code.caric.io/rafaelcaricio/gotosocial/commit/120510ccbfd32f2c2981f28e8d08ed318b371f30) to skip the "published" field when it is not present. But I think the correct way would be the relay to include this field in the activity payload.

