### PR TITLE
Every actor has an unique outbox url

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -56,7 +56,7 @@ impl Actor {
                 url: "https://fedi.buzz/assets/favicon48.png".to_string(),
             }),
             inbox: self.uri(),
-            outbox: format!("https://{}/outbox", self.host),
+            outbox: format!("{}/outbox", self.uri()),
             public_key: activitypub::ActorPublicKey {
                 id: self.key_id(),
                 owner: Some(self.uri()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -350,7 +350,8 @@ async fn main() {
     let app = Router::new()
         .route("/tag/:tag", get(get_tag_actor).post(post_tag_relay))
         .route("/instance/:instance", get(get_instance_actor).post(post_instance_relay))
-        .route("/outbox", get(outbox))
+        .route("/tag/:tag/outbox", get(outbox))
+        .route("/instance/:instance/outbox", get(outbox))
         .route("/.well-known/webfinger", get(webfinger))
         .route("/.well-known/nodeinfo", get(nodeinfo))
         .route("/metrics", get(|| async move {


### PR DESCRIPTION
The fix for #7 is breaking GoToSocial. It expects every actor to have a unique outbox address.

```
22:14:22 - timestamp="07/08/2023 20:14:22.646" func=middleware.Logger.func1.1 level=ERROR latency="150.92003ms" userAgent="Mastodon/591 CFNetwork/1469 Darwin/21.3.0" method=GET statusCode=500 path=/api/v2/search clientIP=172.18.0.1 error="Error #01: Get: error searching by URI: byURI: error looking up https://relay.fedi.buzz/tag/fedibuzz as account: enrichAccount: error putting in database: ERROR: duplicate key value violates unique constraint \"new_accounts_outbox_uri_key\" (SQLSTATE 23505)\n" requestID=3znt5mc904001d50f4v0 msg="Internal Server Error: wrote 54B"
```